### PR TITLE
fixed typo in Marshal documentation

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -213,7 +213,7 @@ func unmarshal(in []byte, out interface{}, strict bool) (err error) {
 //         B int
 //     }
 //     yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
-//     yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
+//     yaml.Marshal(&T{F: 1}) // Returns "a: 1\nb: 0\n"
 //
 func Marshal(in interface{}) (out []byte, err error) {
 	defer handleErr(&err)


### PR DESCRIPTION
The example shown for the Marshal documentation is:
```
type T struct {
    F int `yaml:"a,omitempty"`
    B int
}
yaml.Marshal(&T{B: 2}) // Returns "b: 2\n"
yaml.Marshal(&T{F: 1}} // Returns "a: 1\nb: 0\n"
```

This does not compile due to a typo in the last line. The final func invocation should be:
`yaml.Marshal(&T{F: 1})`, rather than `yaml.Marshal(&T{F: 1}}`